### PR TITLE
Fix Black (formatter) exclusion regex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ sources = ["src", "vendor"]
 [tool.black]
 line-length = 120
 extend-exclude = """(
-      ^/Hexal
+    ^/vendor
+    | ^/Hexal
     | ^/HexMod
     | ^/MoreIotas
     | ^/HexTweaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,7 @@ sources = ["src", "vendor"]
 
 [tool.black]
 line-length = 120
-extend-exclude = """(
-    ^/vendor
-    | ^/Hexal
-    | ^/HexMod
-    | ^/MoreIotas
-    | ^/HexTweaks
-    | ^/HexKinetics
-)"""
+extend-exclude = "^/vendor"
 
 [tool.pyright]
 pythonVersion = "3.11"


### PR DESCRIPTION
None of the original regex options could match because they expect the submodules to be in the root directory (with the configuration), but they're actually in `/vendor`.