### PR TITLE
mediatransport shared stylesheet

### DIFF
--- a/web/src/HexBug/web/_templates/index.css.jinja
+++ b/web/src/HexBug/web/_templates/index.css.jinja
@@ -12,3 +12,5 @@ blockquote > h2 {
   position: absolute;
   margin-top: -14px;
 }
+
+{% include "mediatransport:mediatransport_shared.css.jinja" %}


### PR DESCRIPTION
before:
<img width="823" height="634" alt="image" src="https://github.com/user-attachments/assets/d5c86765-57fa-428d-8de9-21b3e7e3988d" />

after:
<img width="859" height="795" alt="image" src="https://github.com/user-attachments/assets/3bd0f6d3-6c91-45cf-9380-39b4383814a0" />

